### PR TITLE
:sparkles: Add health endpoint and checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,12 @@
 #
 FROM openjdk:17-jdk-slim
 
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
 EXPOSE 8080
-#HEALTHCHECK --interval=10s CMD curl --fail http://localhost:8080/health || exit 1
+HEALTHCHECK --interval=5s CMD curl --fail http://localhost:8080/health || exit 1
 
 COPY target/pwr-mtr-pls-gw-*.jar /usr/local/lib/power-meter-pulse-gateway.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,10 @@
       <artifactId>micronaut-rabbitmq</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-management</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
       <scope>compile</scope>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,10 @@ netty:
     allocator:
       max-order: 3
 
+endpoints:
+    health:
+      enabled: true
+
 # https://micronaut-projects.github.io/micronaut-rabbitmq/latest/guide/#config
 rabbitmq:
   host: ${AMQP_HOST}


### PR DESCRIPTION
The endpoint only exposes the health status, so it can safely be made available with the REST endpoint.

If more privacy is needed later, the port for management endpoints can be changed.