### PR TITLE
:hammer: Refactor API to use ISO 8601 timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Configuration is done using environment variables:
 
 ### Pulse Message
 
-Pulses are encoded as messages with a [UNIX timestamp](https://www.unixtimestamp.com/) in the JSON form
+Pulses are encoded as messages with a [ISO 8601 timestamp](https://en.wikipedia.org/wiki/ISO_8601) in the JSON form
 ```json
 {
-  "timestamp": 1234567890
+  "timestamp": "2022-08-23T16:54:23Z"
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,10 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.micronaut.rabbitmq</groupId>
       <artifactId>micronaut-rabbitmq</artifactId>
     </dependency>

--- a/src/main/java/de/netz39/svc/pwrMtrPlsGw/PulseMessage.java
+++ b/src/main/java/de/netz39/svc/pwrMtrPlsGw/PulseMessage.java
@@ -1,8 +1,11 @@
 package de.netz39.svc.pwrMtrPlsGw;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.context.annotation.Bean;
 import net.jcip.annotations.Immutable;
+
+import java.time.Instant;
 
 /**
  * Bean representation of a pulse message.
@@ -17,18 +20,19 @@ import net.jcip.annotations.Immutable;
 @Immutable
 @Bean
 public class PulseMessage {
-    static PulseMessage withTimestamp(final long timestamp) {
+    static PulseMessage withTimestamp(final Instant timestamp) {
         return new PulseMessage(timestamp);
     }
 
     @JsonProperty("timestamp")
-    private final long timestamp;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private final Instant timestamp;
 
-    PulseMessage(@JsonProperty(value="timestamp", required = true) long timestamp) {
+    PulseMessage(@JsonProperty(value="timestamp", required = true) Instant timestamp) {
         this.timestamp = timestamp;
     }
 
-    public long getTimestamp() {
+    public Instant getTimestamp() {
         return timestamp;
     }
 }

--- a/src/test/java/de/netz39/svc/pwrMtrPlsGw/TestPulseEndpoint.java
+++ b/src/test/java/de/netz39/svc/pwrMtrPlsGw/TestPulseEndpoint.java
@@ -15,6 +15,8 @@ import jakarta.inject.Singleton;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @Singleton
@@ -53,7 +55,7 @@ public class TestPulseEndpoint {
 
     @Test
     public void testValid() {
-        final PulseMessage msg =  PulseMessage.withTimestamp(0);
+        final PulseMessage msg =  PulseMessage.withTimestamp(Instant.EPOCH);
         final HttpRequest<PulseMessage> req = HttpRequest.POST("/pulse", msg);
         assertDoesNotThrow(
                 () -> client.toBlocking().exchange(req)
@@ -80,7 +82,7 @@ public class TestPulseEndpoint {
     public void testMissingRabbitMQ() {
         AmqpTestEmitter.except = new RabbitClientException("Test Exception");
 
-        final PulseMessage msg =  PulseMessage.withTimestamp(0);
+        final PulseMessage msg =  PulseMessage.withTimestamp(Instant.EPOCH);
         final HttpRequest<PulseMessage> req = HttpRequest.POST("/pulse", msg);
 
         final HttpClientResponseException e = assertThrows(
@@ -93,7 +95,7 @@ public class TestPulseEndpoint {
     @Test
     @Property(name = "api-token", value = "abc")
     public void TestValidAuth() {
-        final PulseMessage msg =  PulseMessage.withTimestamp(0);
+        final PulseMessage msg =  PulseMessage.withTimestamp(Instant.EPOCH);
         final MutableHttpRequest<PulseMessage> req = HttpRequest.POST("/pulse", msg).bearerAuth("abc");
         assertDoesNotThrow(
                 () -> client.toBlocking().exchange(req)
@@ -105,7 +107,7 @@ public class TestPulseEndpoint {
     @Test
     @Property(name = "api-token", value = "abc")
     public void TestInvalidAuth() {
-        final PulseMessage msg =  PulseMessage.withTimestamp(0);
+        final PulseMessage msg =  PulseMessage.withTimestamp(Instant.EPOCH);
         final MutableHttpRequest<PulseMessage> req = HttpRequest.POST("/pulse", msg);
         final HttpClientResponseException e = assertThrows(
                 HttpClientResponseException.class,

--- a/src/test/java/de/netz39/svc/pwrMtrPlsGw/TestPulseMessage.java
+++ b/src/test/java/de/netz39/svc/pwrMtrPlsGw/TestPulseMessage.java
@@ -2,9 +2,11 @@ package de.netz39.svc.pwrMtrPlsGw;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -13,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestPulseMessage {
     @Test
     public void testConstructor() {
-        for (final long timestamp: Arrays.asList(-1L, 0L, 1660739950000L)){
+        for (final Instant timestamp: Arrays.asList(Instant.EPOCH, Instant.now())){
             final PulseMessage pm = PulseMessage.withTimestamp(timestamp);
             assertNotNull(pm);
             assertEquals(timestamp, pm.getTimestamp());
@@ -23,14 +25,16 @@ public class TestPulseMessage {
     @Test
     public void testSerialization() {
         ObjectMapper mapper = new ObjectMapper();
-        for (final long timestamp: Arrays.asList(-1L, 0L, 1660739950000L)) {
+        mapper.registerModule(new JavaTimeModule());
+
+        for (final Instant timestamp: Arrays.asList(Instant.EPOCH, Instant.now())){
             // Test a valid JSON input
             final PulseMessage msg = PulseMessage.withTimestamp(timestamp);
             String json = assertDoesNotThrow(
                     () -> mapper.writeValueAsString(msg)
             );
             assertNotNull(json);
-            assertEquals("{\"timestamp\":"+timestamp+"}", json);
+            assertEquals("{\"timestamp\":\""+timestamp+"\"}", json);
         }
 
     }
@@ -38,11 +42,12 @@ public class TestPulseMessage {
     @Test
     public void testDeserialization() {
         ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
 
-        for (final long timestamp: Arrays.asList(-1L, 0L, 1660739950000L)) {
+        for (final Instant timestamp: Arrays.asList(Instant.EPOCH, Instant.now())){
             // Test a valid JSON input
             final PulseMessage msg = assertDoesNotThrow(
-                    () -> mapper.readValue("{\"timestamp\":"+timestamp+"}",
+                    () -> mapper.readValue("{\"timestamp\":\""+timestamp+"\"}",
                             PulseMessage.class)
             );
             assertNotNull(msg);


### PR DESCRIPTION
In the Netz39 Discord chat we decided to use ISO 8601 form instead of UNIX timestamps. This PR introduces the necessary changes.