### PR TITLE
:alien: Change bad gateway code to 502 to match Reverse Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ This call returns one of the following codes:
 * `201` if the call was successful (created)
 * `400` if the body argument is invalid
 * `401` if authorization failed
-* `504` if the AMQP queue is not available.
+* `502` if the AMQP queue is not available.
 
-On return code `504` the call should be retried at a later point. In any other case the call should not be retried.
+On return code `502` the call should be retried at a later point. In any other case the call should not be retried.
+A `502` status code may also be returned by the reverse proxy if the service container is not running.
 
 Please note that idempotency is not considered by the gateway in the sense that an already sent timestamp will not be suppressed.
 

--- a/src/main/java/de/netz39/svc/pwrMtrPlsGw/PulseEndpoint.java
+++ b/src/main/java/de/netz39/svc/pwrMtrPlsGw/PulseEndpoint.java
@@ -41,7 +41,7 @@ public class PulseEndpoint {
     @Operation(summary = "Send a pulse message")
     @ApiResponse(responseCode = "201", description = "AMQP call successful")
     @ApiResponse(responseCode = "400", description = "Invalid call arguments")
-    @ApiResponse(responseCode = "504", description = "Timeout or error while connecting to RabbitMQ, please retry later!")
+    @ApiResponse(responseCode = "502", description = "Timeout or error while connecting to RabbitMQ, please retry later!")
     public HttpStatus pulse(@Body PulseMessage body,
                             @Parameter(description = "Authorization string as `Beaker <token>`, see README for details")
                             @Header(HttpHeaders.AUTHORIZATION) @Nullable String authorization) {
@@ -67,6 +67,6 @@ public class PulseEndpoint {
 
     @Error(exception=RabbitClientException.class)
     public HttpResponse<String> onRabbitClientException(RabbitClientException e) {
-        return HttpResponse.status(HttpStatus.GATEWAY_TIMEOUT).body(e.getMessage());
+        return HttpResponse.status(HttpStatus.BAD_GATEWAY).body(e.getMessage());
     }
 }

--- a/src/test/java/de/netz39/svc/pwrMtrPlsGw/TestPulseEndpoint.java
+++ b/src/test/java/de/netz39/svc/pwrMtrPlsGw/TestPulseEndpoint.java
@@ -89,7 +89,7 @@ public class TestPulseEndpoint {
                 HttpClientResponseException.class,
                 () -> client.toBlocking().exchange(req)
         );
-        assertEquals(HttpStatus.GATEWAY_TIMEOUT.getCode(), e.getStatus().getCode());
+        assertEquals(HttpStatus.BAD_GATEWAY.getCode(), e.getStatus().getCode());
     }
 
     @Test


### PR DESCRIPTION
Apache/Nginx return 502 when the service container is not reachable. Adapt to this HTTP status code to make error handling in the client easier.